### PR TITLE
Better handling of board names containing non-word characters

### DIFF
--- a/backup.rb
+++ b/backup.rb
@@ -50,7 +50,7 @@ boards.each do |board|
 
   logger.info "#{board.id} - Writing data to Dropbox..."
   client = DropboxClient.new(ENV['DROPBOX_ACCESS_TOKEN'])
-  filename = "/#{Date.today}-#{board.name.downcase.gsub(/ /, '-')}-trello.json"
+  filename = "/#{Date.today}-#{board.name.downcase.gsub(/[^\w]/, '-').squeeze('-')}-trello.json"
   client.put_file(filename, json)
   logger.info "#{board.id} - OK"
 end


### PR DESCRIPTION
I noticed that the backups for the "Someday / Maybe" board were inadvertently creating a directory using the first part of the board name and a file using the last part:

* Directory: `2017-06-01-someday-`
* Filename: `-maybe-trello.json`

After this fix, the filename should be:

* Filename: `2017-06-01-someday-maybe-trello.json`

I've checked that all the other existing board names will be unaffected by this change.