### PR TITLE
Upgrade app to use v2 of the Dropbox API

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -5,7 +5,7 @@ ruby '2.2.5'
 gem "dotenv"
 gem "addressable"
 gem "rest-client"
-gem "dropbox-sdk"
+gem "dropbox-sdk-v2"
 gem "whenever"
 gem "recap"
 gem "ruby-trello"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -19,12 +19,23 @@ GEM
       net-ssh (>= 2.0.14)
       net-ssh-gateway (>= 1.1.0)
     chronic (0.10.2)
+    domain_name (0.5.20170404)
+      unf (>= 0.0.5, < 1.0.0)
     dotenv (0.11.1)
       dotenv-deployment (~> 0.0.2)
     dotenv-deployment (0.0.2)
-    dropbox-sdk (1.6.4)
-      json
+    dropbox-sdk-v2 (0.0.3)
+      http (~> 2.0)
     highline (1.6.21)
+    http (2.2.2)
+      addressable (~> 2.3)
+      http-cookie (~> 1.0)
+      http-form_data (~> 1.0.1)
+      http_parser.rb (~> 0.6.0)
+    http-cookie (1.0.3)
+      domain_name (~> 0.5)
+    http-form_data (1.0.3)
+    http_parser.rb (0.6.0)
     i18n (0.6.9)
     json (1.8.1)
     mime-types (2.3)
@@ -54,6 +65,9 @@ GEM
     thread_safe (0.3.4)
     tzinfo (1.2.1)
       thread_safe (~> 0.1)
+    unf (0.1.4)
+      unf_ext
+    unf_ext (0.0.7.4)
     whenever (0.9.2)
       activesupport (>= 2.3.4)
       chronic (>= 0.6.3)
@@ -65,7 +79,7 @@ DEPENDENCIES
   activesupport
   addressable
   dotenv
-  dropbox-sdk
+  dropbox-sdk-v2
   mime-types
   recap
   rest-client

--- a/backup.rb
+++ b/backup.rb
@@ -12,7 +12,7 @@ require 'bundler/setup'
 require 'dotenv'
 require 'addressable/uri'
 require 'restclient'
-require 'dropbox_sdk'
+require 'dropbox'
 require 'date'
 require 'trello'
 
@@ -49,8 +49,8 @@ boards.each do |board|
   logger.info "#{board.id} - OK"
 
   logger.info "#{board.id} - Writing data to Dropbox..."
-  client = DropboxClient.new(ENV['DROPBOX_ACCESS_TOKEN'])
+  client = Dropbox::Client.new(ENV['DROPBOX_ACCESS_TOKEN'])
   filename = "/#{Date.today}-#{board.name.downcase.gsub(/[^\w]/, '-').squeeze('-')}-trello.json"
-  client.put_file(filename, json)
+  client.upload(filename, json)
   logger.info "#{board.id} - OK"
 end


### PR DESCRIPTION
[Dropbox are planning to switch off v1 of their API on 28 Sep 2017][1].

This commit switches the app to use the `dropbox-sdk-v2` gem so that it talks to v2 of the Dropbox API.

[1]: https://blogs.dropbox.com/developers/2017/06/updated-api-v1-deprecation-timeline/